### PR TITLE
Initialize basic Zola demo site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,9 @@
 # The URL the site will be built for
 base_url = "https://dj-ryan.github.io/davidryan.xyz/"
 
+# The title of the site
+title = "David Ryan Demo Site"
+
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Home"
++++
+
+Welcome to the demo site. This is the homepage built with Zola.

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+path = "about"
++++
+
+This is an about page for the demo site.

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Blog"
+sort_by = "date"
+paginate_by = 5
++++
+
+Welcome to the blog!

--- a/content/blog/first-post.md
+++ b/content/blog/first-post.md
@@ -1,0 +1,6 @@
++++
+title = "First Post"
+date = 2024-08-21
++++
+
+This is the first blog post in the demo site.

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,0 +1,10 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+nav a {
+    margin-right: 1rem;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+    <link rel="stylesheet" href="{{ get_url(path='style.css') }}">
+  </head>
+  <body>
+    <nav>
+      <a href="{{ config.base_url }}">Home</a>
+      <a href="{{ get_url(path='about') }}">About</a>
+      <a href="{{ get_url(path='blog') }}">Blog</a>
+    </nav>
+    <main>
+      {% block content %}{% endblock content %}
+    </main>
+  </body>
+</html>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+
+{% block content %}
+<article>
+  <h1>{{ page.title }}</h1>
+  {{ page.content | safe }}
+</article>
+{% endblock content %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} | {{ config.title }}{% endblock title %}
+
+{% block content %}
+<h1>{{ section.title }}</h1>
+{% if section.content %}
+  {{ section.content | safe }}
+{% endif %}
+<ul>
+{% for page in section.pages %}
+  <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+{% endfor %}
+</ul>
+{% endblock content %}


### PR DESCRIPTION
## Summary
- configure site title and enable basic Zola settings
- add home, about, and blog pages with an initial post
- create base, page, and section templates plus simple styling

## Testing
- `zola build` *(fails: bash: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6635df4dc83278f7f2f692981eb83