### PR TITLE
Fetch Zola theme submodule in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
 
       # Install Zola (single binary)
       - name: Install Zola


### PR DESCRIPTION
## Summary
- Ensure GitHub Pages workflow checks out the Serene theme submodule, providing required highlight themes.

## Testing
- `./zola build`


------
https://chatgpt.com/codex/tasks/task_e_68a782829f448327a0d6e836053a0e22